### PR TITLE
Fix trading-service startup crashes

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -193,6 +193,39 @@ services:
       start_period: 10s
   trading-service:
     image: 'trading-service:0.0.1-SNAPSHOT'
+    ports:
+      - '3000:3000'
+    depends_on:
+      trading-db:
+        condition: service_healthy
+    networks:
+      - proxy-net
+      - trading-net
+    environment:
+      - POSTGRES_DSN=postgres://trading_service_user:trading_service_password@trading-db:5432/trading_db?sslmode=disable
+      - USER_SERVICE=http://user-service:8081
+      - BANKING_SERVICE=http://banking-service:8082
+    healthcheck:
+      test: [ "CMD-SHELL", "echo OK" ]
+  trading-db:
+    image: 'postgres:17-alpine'
+    ports:
+      - '5435:5432'
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U trading_service_user -d trading_db" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - trading-net
+    environment:
+      POSTGRES_USER: trading_service_user
+      POSTGRES_PASSWORD: trading_service_password
+      POSTGRES_DB: trading_db
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=en_US.UTF-8"
+      LANG: en_US.utf8
+      LC_ALL: en_US.utf8
 networks:
   broker-net: null
   notification-net: null

--- a/compose.yaml
+++ b/compose.yaml
@@ -198,8 +198,12 @@ services:
     networks:
       - proxy-net
       - trading-net
+    environment:
+      - POSTGRES_DSN=postgres://trading_service_user:trading_service_password@trading-db:5432/trading_db?sslmode=disable
+      - USER_SERVICE=http://user-service:8081
+      - BANKING_SERVICE=http://banking-service:8082
     healthcheck:
-      test: [ "CMD-SHELL", "echo OK"]
+      test: [ "CMD-SHELL", "echo OK" ]
   trading-db:
     image: 'postgres:17-alpine'
     ports:
@@ -216,6 +220,9 @@ services:
       POSTGRES_USER: trading_service_user
       POSTGRES_PASSWORD: trading_service_password
       POSTGRES_DB: trading_db
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=en_US.UTF-8"
+      LANG: en_US.utf8
+      LC_ALL: en_US.utf8
 
 networks:
   broker-net: null

--- a/trading-service/cron/CronJobs.go
+++ b/trading-service/cron/CronJobs.go
@@ -33,7 +33,6 @@ type APIResponse struct {
 
 // cron posao koji resetuje limit agentu svakog dana u 23 59
 func StartScheduler() {
-	createNewActuaries()
 	c := cron.New(cron.WithSeconds())
 	_, err := c.AddFunc("0 59 23 * * *", func() {
 		resetDailyLimits()
@@ -72,7 +71,7 @@ func resetDailyLimits() {
 func createNewActuaries() {
 	data, err := GetActuaries()
 
-	if data == nil && err == nil {
+	if err != nil {
 		return
 	}
 


### PR DESCRIPTION
Trading-service would crash at startup when user-service would be unavailable due to improper error handling.
Also fixed a trading-service crash when running in docker container due to Postgres URL being localhost